### PR TITLE
update postgres dependency (fixes latest version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "dedent": "^0.6.0",
     "mysql": "^2.10.2",
-    "pg": "^4.5.5",
+    "pg": "^6.0.0",
     "pync": "^1.0.1",
     "underscore": "^1.8.3",
     "yargs": "^3.29.0"


### PR DESCRIPTION
checked the changelog, no changes that would mess up this library. fixes an error on the latest release of pg.
