### PR TITLE
remove postgres connection mapping logic

### DIFF
--- a/dialects/postgres-client.js
+++ b/dialects/postgres-client.js
@@ -2,23 +2,8 @@ var pg = require('pg')
 var querystring = require('querystring')
 
 class PostgresClient {
-  constructor (options) {
-    var conString
-    if (typeof options === 'string') {
-      conString = options
-    } else {
-      var dialectOptions = Object.assign({}, options.dialectOptions)
-      Object.keys(dialectOptions).forEach((key) => {
-        var value = dialectOptions[key]
-        if (typeof value === 'boolean') {
-          dialectOptions[key] = value ? 'true' : 'false'
-        }
-      })
-      var query = querystring.stringify(dialectOptions)
-      if (query.length > 0) query = '?' + query
-      conString = `postgres://${options.username}:${options.password}@${options.host}:${options.port || 5432}/${options.database}${query}`
-    }
-    this.conString = conString
+  constructor (conOptions) {
+    this.conOptions = conOptions
   }
 
   dropTables () {
@@ -28,7 +13,7 @@ class PostgresClient {
   connect () {
     return new Promise((resolve, reject) => {
       if (this.client) return resolve()
-      pg.connect(this.conString, (err, client, done) => {
+      pg.connect(this.conOptions, (err, client, done) => {
         if (err) return reject(err)
         this.client = client
         this.done = done


### PR DESCRIPTION
The underlying pg module handles the objects just fine, there is no need to transform them. This code was pretty much doing nothing and causing a ton of bugs and edge cases. This is a non-breaking change.

Fixes the following bugs:
- Object w/ undefined (or null) username
- Object w/ undefined (or null) password
- Object w/ no dialectOptions
- Object w/ complex (non-serializable) data, like a logging function
