### PR TITLE
fix indexes in dot tables

### DIFF
--- a/dialects/postgres.js
+++ b/dialects/postgres.js
@@ -80,7 +80,8 @@ class PostgresDialect {
       })
       .then((indexes) => {
         indexes.forEach((index) => {
-          var table = schema.tables.find((table) => table.name === index.indrelid && table.schema === index.nspname)
+          var tableName = index.indrelid.split('.').pop()
+          var table = schema.tables.find((table) => table.name === tableName && table.schema === index.nspname)
           table.indexes.push({
             name: index.indname,
             schema: table.schema,


### PR DESCRIPTION
For example, the PostGIS extension w/ TIGER data. Index `indrelid` is `tiger.addrfeat`, but thetable is `addrfeat` w/ the schema `tiger`. This fixes that bug by checking the relevant part of the `indrelid` against table name instead of the entire thing.
