### PR TITLE
Added single quotes for default values

### DIFF
--- a/dialects/mysql.js
+++ b/dialects/mysql.js
@@ -6,7 +6,9 @@ class MySQLDialect {
   _quote (str) {
     return '`' + str + '`'
   }
-
+  _singleQuote (str) {
+    return !str ? str : '\'' + str + '\'';
+  }
   describeDatabase (options) {
     var schema = { dialect: 'mysql', sequences: [] }
     var client = new MysqlClient(options)
@@ -27,7 +29,7 @@ class MySQLDialect {
               t.columns = columns.map((column) => ({
                 name: column.Field,
                 nullable: column.Null === 'YES',
-                default_value: column.Default,
+                default_value: this._singleQuote(column.Default),
                 type: column.Type,
                 extra: column.Extra
               }))


### PR DESCRIPTION
When a table has attribute default value  the final create table statement does not include a single quote around the default value, as a result when the query is run in the database it throws a parsing error.